### PR TITLE
Remove expired GPG key workaround from Dockerfile

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,9 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:          
-         - base_image: lcas.lincoln.ac.uk/lcas/ros:jammy-humble
-        # - base_image: nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
-        #  push_tag: jammy-cuda12.2
+         - base_image: lcas.lincoln.ac.uk/lcas/ros-docker-images:jammy-cuda12.2-humble-2
 
     steps:
     - name: Node Js

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,6 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then \
 # Copy the list of APT packages to be installed from the local directory to the container
 COPY .docker/apt-packages.lst /tmp/apt-packages.lst
 
-##!! BODGE!!
-##!! The GPG Key in the upstream image has expired and now makes it so this image cannot be built,
-##!! The below code will update the keys.
-##!! See: https://github.com/LCAS/docker_cuda_desktop/issues/8
-RUN add-apt-repository universe \
-  && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-
 # Update the package list, upgrade installed packages, install the packages listed in apt-packages.lst,
 # remove unnecessary packages, clean up the APT cache, and remove the package list to reduce image size
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:v1.4.2
-ARG BASE_IMAGE=lcas.lincoln.ac.uk/lcas/ros:jammy-humble-cuda-opengl
+ARG BASE_IMAGE=lcas.lincoln.ac.uk/lcas/ros-docker-images:jammy-cuda12.2-humble-2
 
 FROM ${BASE_IMAGE} AS base
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Removes workaround for the expired GPG key issue.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Closes #8 

## QA Instructions, Screenshots, Recordings

Check the container builds successfully.

## [optional] Are there any post deployment tasks we need to perform?

N/A
